### PR TITLE
Fix js-obfuscator dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/devunion/gulp-js-obfuscator/issues"
   },
   "dependencies": {
-    "js-obfuscator": "^0.1.0",
+    "js-obfuscator": "^0.1.2",
     "gulp-util": "^3.0.5",
     "through2": "^2.0.0",
     "multimatch": "^2.0.0"


### PR DESCRIPTION
js-obfuscator scrapes javascriptobfuscator.com, but its DOM changed. v0.1.2 fixed it, and it needs to be updated here too.